### PR TITLE
Filter for Serial Implemtation is added

### DIFF
--- a/Serial Implementation/Filters/gaussian_filter_serial.cpp
+++ b/Serial Implementation/Filters/gaussian_filter_serial.cpp
@@ -1,0 +1,35 @@
+#include "gaussian_filter.h"
+#include <cmath>
+
+cv::Mat GaussianFilterSerial::apply(const cv::Mat& input, int kernelSize, double sigma) {
+    cv::Mat output = cv::Mat::zeros(input.size(), input.type());
+
+    // Create Gaussian kernel
+    int k = kernelSize / 2;
+    std::vector<std::vector<double>> kernel(kernelSize, std::vector<double>(kernelSize));
+    double sum = 0.0;
+
+    for (int i = -k; i <= k; i++) {
+        for (int j = -k; j <= k; j++) {
+            kernel[i + k][j + k] = exp(-(i*i + j*j) / (2 * sigma * sigma));
+            sum += kernel[i + k][j + k];
+        }
+    }
+    for (int i = 0; i < kernelSize; i++)
+        for (int j = 0; j < kernelSize; j++)
+            kernel[i][j] /= sum;
+
+    // Convolution
+    for (int y = k; y < input.rows - k; y++) {
+        for (int x = k; x < input.cols - k; x++) {
+            double val = 0.0;
+            for (int i = -k; i <= k; i++) {
+                for (int j = -k; j <= k; j++) {
+                    val += input.at<uchar>(y + i, x + j) * kernel[i + k][j + k];
+                }
+            }
+            output.at<uchar>(y, x) = cv::saturate_cast<uchar>(val);
+        }
+    }
+    return output;
+}

--- a/Serial Implementation/Filters/laplacian_filter_serial.cpp
+++ b/Serial Implementation/Filters/laplacian_filter_serial.cpp
@@ -1,0 +1,45 @@
+#include "laplacian_filter.h"
+#include <vector>
+#include <stdexcept>
+
+// Laplacian kernel (3x3)
+const std::vector<std::vector<int>> laplacianKernelSerial = {
+    { 0, -1,  0 },
+    {-1,  4, -1},
+    { 0, -1,  0 }
+};
+
+// Apply Laplacian to one channel (serial)
+cv::Mat applyLaplacianChannelSerial(const cv::Mat& input) {
+    int pad = 1;
+    cv::Mat output = cv::Mat::zeros(input.size(), input.type());
+
+    for (int i = pad; i < input.rows - pad; i++) {
+        for (int j = pad; j < input.cols - pad; j++) {
+            int sum = 0;
+            for (int ki = -pad; ki <= pad; ki++) {
+                for (int kj = -pad; kj <= pad; kj++) {
+                    int pixel = input.at<uchar>(i + ki, j + kj);
+                    sum += pixel * laplacianKernelSerial[ki + pad][kj + pad];
+                }
+            }
+            output.at<uchar>(i, j) = cv::saturate_cast<uchar>(sum);
+        }
+    }
+    return output;
+}
+
+cv::Mat LaplacianFilterSerial::apply(const cv::Mat& input) {
+    if (input.channels() == 1) {
+        return applyLaplacianChannelSerial(input);
+    }
+
+    std::vector<cv::Mat> channels, outChannels(3);
+    cv::split(input, channels);
+    for (int c = 0; c < 3; c++) {
+        outChannels[c] = applyLaplacianChannelSerial(channels[c]);
+    }
+    cv::Mat output;
+    cv::merge(outChannels, output);
+    return output;
+}

--- a/Serial Implementation/Filters/sharpening_filter_serial.cpp
+++ b/Serial Implementation/Filters/sharpening_filter_serial.cpp
@@ -1,0 +1,58 @@
+#include "sharpening_filter.h"
+#include <iostream>
+#include <vector>
+#include <cmath>
+#include <stdexcept>
+#include <chrono>
+
+// Sharpening kernel (3x3)
+const std::vector<std::vector<int>> sharpeningKernelSerial = {
+    { 0, -1,  0 },
+    {-1,  5, -1},
+    { 0, -1,  0 }
+};
+
+// Apply sharpening to one channel (serial)
+cv::Mat applySharpenChannelSerial(const cv::Mat& input) {
+    int padding = 1;
+    cv::Mat output = cv::Mat::zeros(input.size(), input.type());
+
+    for (int i = padding; i < input.rows - padding; i++) {
+        for (int j = padding; j < input.cols - padding; j++) {
+            int sum = 0;
+            for (int ki = -padding; ki <= padding; ki++) {
+                for (int kj = -padding; kj <= padding; kj++) {
+                    int pixel = input.at<uchar>(i + ki, j + kj);
+                    sum += pixel * sharpeningKernelSerial[ki + padding][kj + padding];
+                }
+            }
+            output.at<uchar>(i, j) = cv::saturate_cast<uchar>(sum);
+        }
+    }
+    return output;
+}
+
+cv::Mat SharpeningFilterSerial::apply(const cv::Mat& input) {
+    std::cout << "=== SEQUENTIAL SHARPENING FILTER ===" << std::endl;
+    auto start = std::chrono::high_resolution_clock::now();
+
+    cv::Mat output;
+    if (input.channels() == 1) {
+        output = applySharpenChannelSerial(input);
+    } else if (input.channels() == 3) {
+        std::vector<cv::Mat> channels(3), outChannels(3);
+        cv::split(input, channels);
+        for (int c = 0; c < 3; c++)
+            outChannels[c] = applySharpenChannelSerial(channels[c]);
+        cv::merge(outChannels, output);
+    } else {
+        throw std::runtime_error("Unsupported number of channels.");
+    }
+
+    auto end = std::chrono::high_resolution_clock::now();
+    std::cout << "Sequential processing time: "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()
+              << " ms" << std::endl;
+
+    return output;
+}

--- a/Serial Implementation/Filters/sobel_filter_serial.cpp
+++ b/Serial Implementation/Filters/sobel_filter_serial.cpp
@@ -1,0 +1,57 @@
+#include "sobel_filter.h"
+#include <opencv2/opencv.hpp>
+#include <vector>
+#include <cmath>
+#include <stdexcept>
+
+// Sobel kernels
+const std::vector<std::vector<int>> sobelX = {
+    {-1, 0, 1},
+    {-2, 0, 2},
+    {-1, 0, 1}
+};
+
+const std::vector<std::vector<int>> sobelY = {
+    {-1, -2, -1},
+    { 0,  0,  0},
+    { 1,  2,  1}
+};
+
+// Apply Sobel filter to one channel (serial)
+cv::Mat applySobelChannelSerial(const cv::Mat& input) {
+    int padding = 1;
+    cv::Mat output = cv::Mat::zeros(input.size(), input.type());
+
+    for (int i = padding; i < input.rows - padding; i++) {
+        for (int j = padding; j < input.cols - padding; j++) {
+            int gx = 0, gy = 0;
+            for (int ki = -padding; ki <= padding; ki++) {
+                for (int kj = -padding; kj <= padding; kj++) {
+                    int pixel = input.at<uchar>(i + ki, j + kj);
+                    gx += pixel * sobelX[ki + padding][kj + padding];
+                    gy += pixel * sobelY[ki + padding][kj + padding];
+                }
+            }
+            int mag = static_cast<int>(std::sqrt(gx*gx + gy*gy));
+            output.at<uchar>(i, j) = cv::saturate_cast<uchar>(mag);
+        }
+    }
+    return output;
+}
+
+cv::Mat SobelFilterSerial::apply(const cv::Mat& input) {
+    cv::Mat output;
+    if (input.channels() == 1) {
+        output = applySobelChannelSerial(input);
+    } else if (input.channels() == 3) {
+        std::vector<cv::Mat> channels(3), outChannels(3);
+        cv::split(input, channels);
+        for (int c = 0; c < 3; c++) {
+            outChannels[c] = applySobelChannelSerial(channels[c]);
+        }
+        cv::merge(outChannels, output);
+    } else {
+        throw std::runtime_error("Unsupported number of channels");
+    }
+    return output;
+}


### PR DESCRIPTION
## Summary by Sourcery

Add serial implementations of common image filters with per-channel convolution support and channel handling.

New Features:
- Implement a sequential sharpening filter with timing output and support for single- and three-channel images
- Add a serial Sobel edge detection filter handling grayscale and RGB inputs
- Introduce a serial Laplacian filter for edge enhancement on single- and three-channel images
- Provide a serial Gaussian blur filter with configurable kernel size and sigma